### PR TITLE
Simplify contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,14 @@
-## Contributing In General
-Our project welcomes external contributions! If you have an itch, please feel free to scratch it.
+# Contributing
 
-To contribute code or documentation, please submit a pull request to the [GitHub repository](https://github.com/IBM/ogs-serverless-apis).
+This is an open source project, and we appreciate your help!
 
-A good way to familiarize yourself with the codebase and contribution process is to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/IBM/ogs-serverless-apis/issues). Before embarking on a more ambitious contribution, please quickly [get in touch](#communication) with us.
+We use the GitHub issue tracker to discuss new features and non-trivial bugs.
 
-**We appreciate your effort, and want to avoid a situation where a contribution requires extensive rework (by you or by us), sits in the queue for a long time, or cannot be accepted at all!**
+In addition to the issue tracker, [#journeys on
+Slack](https://dwopen.slack.com) is the best way to get into contact with the
+project's maintainers.
 
-### Proposing new features
-
-If you would like to implement a new feature, please [raise an issue](https://github.com/IBM/ogs-serverless-apis/issues) before sending a pull request so the feature can be discussed.
-This is to avoid you spending your valuable time working on a feature that the project developers are not willing to accept into the code base.
-
-### Fixing bugs
-
-If you would like to fix a bug, please [raise an issue](https://github.com/IBM/ogs-serverless-apis/issues) before sending a pull request so it can be discussed.
-If the fix is trivial or non controversial then this is not usually necessary.
-
-### Merge approval
-
-The project maintainers use LGTM (Looks Good To Me) in comments on the code review to
-indicate acceptance. A change requires LGTMs from two of the maintainers of each
-component affected.
-
-For more details, see the [MAINTAINERS](MAINTAINERS.md) page.
-
-## Communication
-Please feel free to connect with us on our [Slack channel](https://dwopen.slack.com).
-
-## Setup
-Please add any special setup instructions for your project to help the developer become productive quickly.
-
-## Testing
-Please provide information that helps the developer test any changes they make before submitting.
-
-## Coding style guidelines
-Beautiful code rocks! Please share any specific style guidelines you might have for your project.
+To contribute code, documentation, or tests, please submit a pull request to
+the GitHub repository. Generally, we expect two maintainers to review your pull
+request before it is approved for merging. For more details, see the
+[MAINTAINERS](MAINTAINERS.md) page.


### PR DESCRIPTION
This replaces the contributing doc with one that's much simpler, which basically just says 'we welcome contributions, and follow the normal GitHub workflow'.